### PR TITLE
Add plotter manager for Silhouette devices

### DIFF
--- a/silhouette/__init__.py
+++ b/silhouette/__init__.py
@@ -1,1 +1,8 @@
+"""Silhouette helper package."""
+
 # __init__ is needed for import statements across subdirectories.
+
+from .plotter_manager import PlotterManager
+
+__all__ = ["PlotterManager"]
+

--- a/silhouette/plotter_manager.py
+++ b/silhouette/plotter_manager.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import subprocess
+from typing import List, Dict, Optional
+
+try:
+    import usb.core  # type: ignore
+except Exception:  # pragma: no cover
+    usb = None
+else:
+    usb = usb.core
+
+from .Graphtec import DEVICE, VENDOR_ID_GRAPHTEC, SilhouetteCameo
+
+class PlotterManager:
+    """High level helper to discover and drive Silhouette plotters."""
+
+    def __init__(self, log=None):
+        self.log = log if log is not None else sys.stdout
+
+    # ------------------------------------------------------------------
+    def find_plotters(self) -> List[Dict[str, int]]:
+        """Return a list of connected plotters understood by this package."""
+        found: List[Dict[str, int]] = []
+        if usb is None:
+            return found
+
+        for hardware in DEVICE:
+            try:
+                dev = usb.find(
+                    idVendor=hardware['vendor_id'],
+                    idProduct=hardware['product_id'],
+                )
+            except Exception:
+                dev = None
+            if dev is not None:
+                found.append(hardware)
+        return found
+
+    # ------------------------------------------------------------------
+    def install_drivers(self) -> None:
+        """Try to ensure the operating system has the required drivers."""
+        platform = sys.platform.lower()
+        if platform.startswith('linux'):
+            rules_dst = '/etc/udev/rules.d/99-silhouette.rules'
+            if not os.path.exists(rules_dst):
+                rules_src = os.path.join(os.path.dirname(__file__), '..', 'silhouette-udev.rules')
+                subprocess.run(['sudo', 'cp', rules_src, rules_dst], check=False)
+                subprocess.run(['sudo', 'udevadm', 'control', '--reload-rules'], check=False)
+                subprocess.run(['sudo', 'udevadm', 'trigger'], check=False)
+        elif platform.startswith('win'):
+            zadig = os.path.join('distribute', 'win', 'zadig-2.4.exe')
+            if os.path.exists(zadig):
+                subprocess.Popen(['start', '', zadig], shell=True)
+        # macOS currently requires manual driver installation
+
+    # ------------------------------------------------------------------
+    def connect(self, dry_run: bool = False) -> SilhouetteCameo:
+        """Connect to the first available plotter and return the driver object."""
+        return SilhouetteCameo(log=self.log, dry_run=dry_run)
+
+    # ------------------------------------------------------------------
+    def send_svg_to_cut(self, svg_path: str, args: Optional[List[str]] = None) -> None:
+        """Send an SVG file to the connected plotter for cutting."""
+        from sendto_silhouette import SendtoSilhouette
+
+        effect = SendtoSilhouette()
+        cmd_args = args[:] if args else []
+        cmd_args.append(svg_path)
+        effect.run(cmd_args)

--- a/test/test_plotter_manager.py
+++ b/test/test_plotter_manager.py
@@ -1,0 +1,7 @@
+from silhouette import PlotterManager
+
+
+def test_find_plotters_returns_list():
+    pm = PlotterManager()
+    devices = pm.find_plotters()
+    assert isinstance(devices, list)


### PR DESCRIPTION
## Summary
- introduce `PlotterManager` helper to discover, connect, and drive Silhouette plotters
- expose new manager through package init and add basic tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'inkex')*
- `pip install inkex` *(fails: Could not find a version that satisfies the requirement inkex)*
- `pytest test/test_plotter_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6899dabe81f08324aee0a897ad341bc4